### PR TITLE
allow an explicit empty string as a splitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var es = require('event-stream'),
 module.exports = function(opt){
   // clone options
   opt = opt ? clone(opt) : {};
-  if (!opt.splitter && opt.splitter !== "") opt.splitter = '\r\n';
+  if (typeof opt.splitter === 'undefined') opt.splitter = '\r\n';
 
   if (!opt.fileName) throw new Error("Missing fileName option for gulp-concat");
 


### PR DESCRIPTION
Just checking for negative will be true for an empty string if explicitly defined.  This change allows an empty string to be defined as a splitter.
