### PR TITLE
Need to buffer file contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function(fileName, opt){
       cwd: buffer[0].cwd,
       base: buffer[0].base,
       path: joinedPath,
-      contents: joinedContents
+      contents: new Buffer(joinedContents)
     });
 
     this.emit('data', joinedFile);


### PR DESCRIPTION
This is a strange bug. I was using concat a few days ago without issue, then it stopped working for some unknown reason. It could be because of an update to gulp, I'm not sure. Either way buffering the content seems to have fixed it.
