### PR TITLE
Added optional argument to concat input in reverse order.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function(fileName, opt) {
   var buffer = [];
   var firstFile = null;
   var newLineBuffer = opt.newLine ? new Buffer(opt.newLine) : null;
+  var reverseOrder = opt.reverse;
 
   function bufferContents(file) {
     if (file.isNull()) return; // ignore
@@ -28,7 +29,7 @@ module.exports = function(fileName, opt) {
   function endStream() {
     if (buffer.length === 0) return this.emit('end');
 
-    var joinedContents = Buffer.concat(buffer);
+    var joinedContents = Buffer.concat(reverseOrder ? buffer.reverse() : buffer);
 
     var joinedPath = path.join(firstFile.base, fileName);
 

--- a/test/main.js
+++ b/test/main.js
@@ -13,21 +13,29 @@ describe('gulp-concat', function() {
     testFiles(concat('test.js'), input, 'wadup');
     testFiles(concat('test.js', {newLine: '\r\n'}), input, 'wadup');
     testFiles(concat('test.js', {newLine: ''}), input, 'wadup');
+    testFiles(concat('test.js', {newLine: '\r\n', reverse: true}), input, 'wadup');
+    testFiles(concat('test.js', {newLine: '', reverse: true}), input, 'wadup');
 
     input = ['wadup', 'doe'];
     testFiles(concat('test.js'), input, 'wadup\ndoe');
     testFiles(concat('test.js', {newLine: '\r\n'}), input, 'wadup\r\ndoe');
     testFiles(concat('test.js', {newLine: ''}), input, 'wadupdoe');
+    testFiles(concat('test.js', {newLine: '\r\n', reverse: true}), input, 'doe\r\nwadup');
+    testFiles(concat('test.js', {newLine: '', reverse: true}), input, 'doewadup');
 
     input = ['wadup', 'doe', 'hey'];
     testFiles(concat('test.js'), input, 'wadup\ndoe\nhey');
     testFiles(concat('test.js', {newLine: '\r\n'}), input, 'wadup\r\ndoe\r\nhey');
     testFiles(concat('test.js', {newLine: ''}), input, 'wadupdoehey');
+    testFiles(concat('test.js', {newLine: '\r\n', reverse: true}), input, 'hey\r\ndoe\r\nwadup');
+    testFiles(concat('test.js', {newLine: '', reverse: true}), input, 'heydoewadup');
 
     input = [[65, 66], [67, 68], [69, 70]];
     testFiles(concat('test.js'), input, 'AB\nCD\nEF');
     testFiles(concat('test.js', {newLine: '\r\n'}), input, 'AB\r\nCD\r\nEF');
     testFiles(concat('test.js', {newLine: ''}), input, 'ABCDEF');
+    testFiles(concat('test.js', {newLine: '\r\n', reverse: true}), input, 'EF\r\nCD\r\nAB');
+    testFiles(concat('test.js', {newLine: '', reverse: true}), input, 'EFCDAB');
 
     function testFiles(stream, contentses, result) {
       it('should concat one or several files', function(done) {


### PR DESCRIPTION
This is a follow-up to https://github.com/wearefractal/gulp-concat/issues/35. I've added tests as well to test the new argument in combination with `newLine`. Please feel free to reject it if you don't believe this should be a part of gulp-concat.
