### PR TITLE
Add support for gulp-sourcemaps (from its creator)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "through": "^2.3.4",
-    "gulp-util": "^2.2.5"
+    "concat-with-sourcemaps": "^0.1.1",
+    "gulp-util": "^2.2.5",
+    "through": "^2.3.4"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Hello, sorry for adding another pull request on this. I got requests from different users of `gulp-sourcemaps` that are currently using my `gulp-concat` fork to send a pull request here, so they can use the normal plugin:
- I tried to leave your plugin as readable as possible
- all the concatenation and source mapping logic is in an external package
- full test coverage on the package: [concat-with-sourcemaps](https://github.com/floridoo/concat-with-sourcemaps)
  I hope that you like this version so it can be merged soon.
