### PR TITLE
43 gulp concat with sourcemaps bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(fileName, opt) {
     if (!firstFile) firstFile = file;
     if (!concat) concat = new Concat(!!firstFile.sourceMap, fileName, opt.newLine);
 
-    concat.add(file.relative, file.contents.toString(), file.sourceMap);
+    concat.add(file.path, file.contents.toString(), file.sourceMap);
   }
 
   function endStream() {


### PR DESCRIPTION
issue: #43 

The last update of gulp-concat, which supports sourcemaps isn't working properly. Below you have the output:

``` bash
./node_modules/.bin/gulp
[13:07:59] Using gulpfile ~/boards-ui/gulpfile.js
[13:07:59] Starting 'buildScripts'...
[13:07:59] Starting 'buildStyles'...
[13:07:59] Starting 'watch'...
[13:07:59] Finished 'watch' after 14 ms
gulp-sourcemap: source file not found:/Users/catalinm/boards-ui/src/styles/clearfix.less
gulp-sourcemap: source file not found:/Users/catalinm/boards-ui/src/styles/headings.less
gulp-sourcemap: source file not found:/Users/catalinm/boards-ui/src/styles/hello-world.less
gulp-sourcemap: source file not found:/Users/catalinm/boards-ui/src/styles/box-shadow.less
gulp-sourcemap: source file not found:/Users/catalinm/boards-ui/src/styles/typography.less
```

`gulpfile.js` snippet:

``` javascript
gulp.task('buildStyles', function(){
  return gulp.src(paths.build.styles)
    .pipe(plumber())
    .pipe(sourcemaps.init())
    .pipe(concat('boards.less'))
    .pipe(less())
    .pipe(sourcemaps.write('./maps'))
    .pipe(gulp.dest(paths.build.outputPath));
});
```

The fix is quite easy, file.path wasn't mentioned right 
