### PR TITLE
Fixed bug when no files were inputted

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,18 +26,21 @@ module.exports = function(fileName, opt) {
   }
 
   function endStream() {
-    var joinedPath = path.join(firstFile.base, fileName);
+    if (firstFile) {
+      var joinedPath = path.join(firstFile.base, fileName);
 
-    var joinedFile = new File({
-      cwd: firstFile.cwd,
-      base: firstFile.base,
-      path: joinedPath,
-      contents: new Buffer(concat.content)
-    });
-    if (concat.sourceMapping)
-      joinedFile.sourceMap = JSON.parse(concat.sourceMap);
+      var joinedFile = new File({
+        cwd: firstFile.cwd,
+        base: firstFile.base,
+        path: joinedPath,
+        contents: new Buffer(concat.content)
+      });
+      if (concat.sourceMapping)
+        joinedFile.sourceMap = JSON.parse(concat.sourceMap);
 
-    this.emit('data', joinedFile);
+      this.emit('data', joinedFile);
+    }
+
     this.emit('end');
   }
 

--- a/test/main.js
+++ b/test/main.js
@@ -59,5 +59,11 @@ describe('gulp-concat', function() {
         stream.end();
       });
     }
+
+    it('should not fail if no files were input', function(done) {
+      var stream = concat('test.js');
+      stream.end();
+      done();
+    });
   });
 });


### PR DESCRIPTION
If no files were inputted to the stream, it would fail while closing the
concat stream.

This test case fails before the fix:

```
it('should not fail if no files were input', function(done) {
    var stream = concat('test.js');
    stream.end();
    done();
})
```

The fix was about enclosing the end of the stream in a simple `if` statement.

The error message can be seem on the issue #46.

Closes #46
