### PR TITLE
Defaulting new file stat to first file stat

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ module.exports = function(fileName, opt) {
         cwd: firstFile.cwd,
         base: firstFile.base,
         path: joinedPath,
-        contents: new Buffer(concat.content)
+        contents: new Buffer(concat.content),
+        stat: firstFile.stat
       });
       if (concat.sourceMapping)
         joinedFile.sourceMap = JSON.parse(concat.sourceMap);

--- a/test/main.js
+++ b/test/main.js
@@ -44,6 +44,7 @@ describe('gulp-concat', function() {
           newFile.relative.should.equal('test.js');
           String(newFile.contents).should.equal(result);
           Buffer.isBuffer(newFile.contents).should.equal(true);
+          newFile.stat.mode.should.equal(0666);
           done();
         });
 
@@ -52,7 +53,8 @@ describe('gulp-concat', function() {
             cwd: '/home/contra/',
             base: '/home/contra/test',
             path: '/home/contra/test/file' + i.toString() + '.js',
-            contents: new Buffer(contents)
+            contents: new Buffer(contents),
+            stat: {mode: 0666}
           }));
         });
 


### PR DESCRIPTION
This is in response to https://github.com/wearefractal/gulp-concat/issues/51.

`gulp-concat` is likely to be applied on a family of files that are related I.E. `js`, `css`.  In this scenario it's likely they will share the same stat mode, uid, gid etc.

What I'm not sure of is whether this is too drastic.  Should we whitelist properties from stat?
