### PR TITLE
Bump concat-with-sourcemaps to ^0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "concat-with-sourcemaps": "^0.1.1",
+    "concat-with-sourcemaps": "^0.1.3",
     "gulp-util": "^2.2.5",
     "through": "^2.3.4"
   },


### PR DESCRIPTION
- Prevents unintentionally installing 0.1.1.
- 0.1.1 can throw `source file not found` errors in `gulp-sourcemaps`.
