### PR TITLE
Don't corrupt binary files (fixes #71)

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(file, opt) {
     }
 
     // add file to concat instance
-    concat.add(file.relative, file.contents.toString(), file.sourceMap);
+    concat.add(file.relative, file.contents, file.sourceMap);
   }
 
   function endStream() {
@@ -81,7 +81,7 @@ module.exports = function(file, opt) {
       joinedFile = firstFile;
     }
 
-    joinedFile.contents = new Buffer(concat.content);
+    joinedFile.contents = concat.content;
 
     if (concat.sourceMapping) {
       joinedFile.sourceMap = JSON.parse(concat.sourceMap);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "concat-with-sourcemaps": "^0.1.3",
+    "concat-with-sourcemaps": "^1.0.0",
     "gulp-util": "^3.0.1",
     "through": "^2.3.4"
   },


### PR DESCRIPTION
Fix for #71 using the new version of `concat-with-sourcemaps` (it uses Buffers instead of strings for the file content)
