### PR TITLE
docs(readme): fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gulp.task('scripts', function() {
 });
 ```
 
-This will concat files by your operating systems newLine. It will take the base directory from the first file that passes through it.
+This will concat files by your operating system's newLine. It will take the base directory from the first file that passes through it.
 
 Files will be concatenated in the order that they are specified in the `gulp.src` function. For example, to concat `./lib/file3.js`, `./lib/file1.js` and `./lib/file2.js` in that order, the following code will create a task to do that:
 
@@ -48,7 +48,7 @@ gulp.task('scripts', function() {
 });
 ```
 
-To change the newLine simply pass an object as the second argument to concat with newLine being whatever (\r\n if you want to support any OS to look at it)
+To change the newLine simply pass an object as the second argument to concat with newLine being whatever (`\r\n` if you want to support any OS to look at it)
 
 For instance:
 


### PR DESCRIPTION
format `\r\n` example